### PR TITLE
健壮性提升以及多Pages对象缺失的处理

### DIFF
--- a/caj2pdf
+++ b/caj2pdf
@@ -2,7 +2,7 @@
 
 import argparse
 from subprocess import call
-from parser import CAJParser
+from cajparser import CAJParser
 from utils import add_outlines
 
 if __name__ == "__main__":

--- a/cajparser.py
+++ b/cajparser.py
@@ -1,0 +1,143 @@
+import struct
+from subprocess import call
+from utils import *
+
+
+class CAJParser(object):
+    def __init__(self, filename):
+        self.filename = filename
+        try:
+            with open(filename, "rb") as caj:
+                fmt = struct.unpack("4s", caj.read(4))[0].replace(b'\x00', b'').decode("gb18030")
+            if fmt == "CAJ":
+                self.format = "CAJ"
+                self._PAGE_NUMBER_OFFSET = 0x10
+                self._TOC_NUMBER_OFFSET = 0x110
+            elif fmt == "HN":
+                self.format = "HN"
+                self._PAGE_NUMBER_OFFSET = 0x90
+                self._TOC_NUMBER_OFFSET = 0x158
+            else:
+                self.format = None
+                raise SystemExit("Unknown file type.")
+        except UnicodeDecodeError:
+            raise SystemExit("Unknown file type.")
+
+    @property
+    def page_num(self):
+        with open(self.filename, "rb") as caj:
+            caj.seek(self._PAGE_NUMBER_OFFSET)
+            [page_num] = struct.unpack("i", caj.read(4))
+            return page_num
+
+    @property
+    def toc_num(self):
+        with open(self.filename, "rb") as caj:
+            caj.seek(self._TOC_NUMBER_OFFSET)
+            [toc_num] = struct.unpack("i", caj.read(4))
+            return toc_num
+
+    def get_toc(self):
+        toc = []
+        with open(self.filename, "rb") as caj:
+            for i in range(self.toc_num):
+                caj.seek(self._TOC_NUMBER_OFFSET + 4 + 0x134 * i)
+                toc_bytes = struct.unpack("256s24s12s12si", caj.read(0x134))
+                ttl_end = toc_bytes[0].find(b"\x00")
+                title = toc_bytes[0][0:ttl_end].decode("gb18030").encode("utf-8")
+                pg_end = toc_bytes[2].find(b"\x00")
+                page = int(toc_bytes[2][0:pg_end])
+                level = toc_bytes[4]
+                toc_entry = {"title": title, "page": page, "level": level}
+                toc.append(toc_entry)
+        return toc
+
+    def output_toc(self, dest):
+        toc_items = self.get_toc()
+        with open(dest, "wb") as f:
+            for toc in toc_items:
+                f.write(b'    ' * (toc["level"] - 1) + toc["title"]
+                        + b'    ' + str(toc["page"]).encode("utf-8") + b'\n')
+
+    def convert(self, dest):
+        if self.format == "CAJ":
+            self._convert_caj(dest)
+        elif self.format == "HN":
+            self._convert_hn(dest)
+
+    def _convert_caj(self, dest):
+        caj = open(self.filename, "rb")
+
+        # Extract original PDF data (and add header)
+        caj.seek(self._PAGE_NUMBER_OFFSET + 4)
+        [pdf_start_pointer] = struct.unpack("i", caj.read(4))
+        caj.seek(pdf_start_pointer)
+        [pdf_start] = struct.unpack("i", caj.read(4))
+        pdf_end = fnd_all(caj, b"endobj")[-1] + 6
+        pdf_length = pdf_end - pdf_start
+        caj.seek(pdf_start)
+        pdf_data = b"%PDF-1.3\r\n" + caj.read(pdf_length) + b"\r\n"
+        with open("pdf.tmp", 'wb') as f:
+            f.write(pdf_data)
+        pdf = open("pdf.tmp", "rb")
+        
+        # deal with disordered PDF data -- to get obj_dict & cntts2pg
+        endobj_addr = fnd_all(pdf, b"endobj")
+        obj_dict = {}  # object # -> object
+        cntts2pg = {}  # contents -> page obj # & parent obj #
+        for addr in endobj_addr:
+            st_ = fnd_rvrs(pdf, b" 0 obj", addr)
+            st_ = max(fnd_rvrs(pdf, b"\r", st_), fnd_rvrs(pdf, b"\n", st_))  # '\r' or '\n' before object
+            no = rd_int(pdf, st_)
+            if no not in obj_dict:
+                obj_len = addr - st_ + 6
+                pdf.seek(st_)
+                [obj] = struct.unpack(str(obj_len)+"s", pdf.read(obj_len))
+                if obj.find(b"/Pages") >= 0:  # discard all pages object(s)
+                    continue
+                obj_dict[no] = obj
+                if obj.find(b"/Contents") >= 0:  # equivalent to that this is a page object
+                    con_st = fnd(pdf, b"/Contents ", st_) + 10 + (obj.find(b"/Contents [")>=0)  # only one contents # is needed
+                    contents = rd_int(pdf, con_st)
+                    parent_st = fnd(pdf, b"/Parent ", st_) + 8
+                    parent = rd_int(pdf, parent_st)
+                    cntts2pg[contents] = {'page': no, 'parent': parent}
+        # generate catelog obj # & root pages obj (the only pages obj) #
+        ctlg_no = fnd_unuse_no(list(obj_dict.keys()), [])
+        root_pgs_no = fnd_unuse_no(list(obj_dict.keys()), [ctlg_no])
+        # determine root pages obj's kids
+        kids = []
+        for no in obj_dict:
+            if no in cntts2pg:
+                pg = cntts2pg[no]['page']
+                kids.append(pg)   # ordered as the order in which contents objs appear in .caj file
+                old = bytes("/Parent {0}".format(cntts2pg[no]['parent']), 'utf-8')
+                new = bytes("/Parent {0}".format(root_pgs_no), 'utf-8')
+                obj_dict[pg].replace(old, new)  # change all page objects' parent to root pages obj
+        # generate catalog obj, root pages obj and final pdf data
+        catalog = bytes("{0} 0 obj\r<</Type /Catalog\r/Pages {1} 0 R\r>>\rendobj\r".format(
+            ctlg_no, root_pgs_no), "utf-8")
+        kids_str = ["{0} 0 R".format(i) for i in kids]
+        kids_strs = "[{0}]".format(" ".join(kids_str))
+        pages = bytes("{0} 0 obj\r<<\r/Type /Pages\r/Kids {1}\r/Count {2}\r>>\rendobj\r".format(
+            root_pgs_no, kids_strs, self.page_num), 'utf-8')
+        objs = list(obj_dict.values())
+        pdf_data = b"%PDF-1.3\r\n"
+        for obj in objs:
+            pdf_data += b'\r' + obj
+        pdf_data += b'\r' + pages + b'\r' + catalog
+        pdf_data += b"\n%%EOF\r"
+        # write pdf data to file
+        with open("pdf.tmp", 'wb') as f:
+            f.write(pdf_data)
+
+        # Use mutool to repair xref
+        call(["mutool", "clean", "pdf.tmp", "pdf_toc.pdf"])
+
+        # Add Outlines
+        add_outlines(self.get_toc(), "pdf_toc.pdf", dest)
+        call(["rm", "-f", "pdf.tmp"])
+        call(["rm", "-f", "pdf_toc.pdf"])
+
+    def _convert_hn(self, dest):
+        raise SystemExit("Unsupported file type.")

--- a/parser.py
+++ b/parser.py
@@ -116,7 +116,11 @@ class CAJParser(object):
             pdf.seek(addr)
             [ind] = struct.unpack(str(length) + "s", pdf.read(length))
             inds.append(int(ind))
-        pages_obj_no = list(set(inds))
+        # get pages_obj_no list containing distinct elements
+        pages_obj_no = []
+        for ind in inds:
+            if ind not in pages_obj_no:
+                pages_obj_no.append(ind)
         # find missing pages object(s) -- top pages object(s) in pages_obj_no
         top_pages_obj_no = []
         for pon in pages_obj_no:

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ import os
 import sys
 import PyPDF2.pdf as PDF
 from PyPDF2 import PdfFileWriter, PdfFileReader
+import struct
 
 
 class Node(object):
@@ -136,15 +137,27 @@ def fnd_all(f, s):
             return results
 
 
-def fnd_unuse_no(obj_no, top_pages_obj_no):
+def fnd_unuse_no(nos1, nos2):
     unuse_no = -1
     for i in range(9999):
-        if (i + 1 not in obj_no) and (i + 1 not in top_pages_obj_no):
+        if (i + 1 not in nos1) and (i + 1 not in nos2):
             unuse_no = i + 1
             break
     if unuse_no == -1:
         raise SystemExit("Error on PDF objects numbering.")
     return unuse_no
+
+
+def rd_int(f, start_addr, stop_mark=[b" "]):
+    length = 0
+    while True:
+        f.seek(start_addr + length)
+        [_str] = struct.unpack("s", f.read(1))
+        if _str in stop_mark:
+            f.seek(start_addr)
+            [n] = struct.unpack(str(length)+'s', f.read(length))
+            return int(n)
+        length += 1
 
 
 def make_dest(pdfw, pg):

--- a/utils.py
+++ b/utils.py
@@ -136,26 +136,15 @@ def fnd_all(f, s):
             return results
 
 
-def fnd_unuse_no(pdf, top_pages_obj_no):
-        # find catalog_obj_no
-        catalog_obj_no = -1
-        for i in range(9999):
-            if fnd(pdf, bytes("{0} 0 obj".format(i + 1), "utf-8")) == -1 and not (i + 1 in top_pages_obj_no):
-                catalog_obj_no = i + 1
-                break
-        if catalog_obj_no == -1:
-            raise SystemExit("Error on PDF Catalog objects numbering.")
-        # find root pages_obj_no if multiple pages objects misssed
-        if len(top_pages_obj_no) > 1:
-            root_pages_obj_no = -1
-            for j in range(9999 - catalog_obj_no):
-                if fnd(pdf, bytes("{0} 0 obj".format(j + catalog_obj_no + 1), "utf-8")) == -1 and not (j + catalog_obj_no + 1 in top_pages_obj_no):
-                    root_pages_obj_no = j + catalog_obj_no + 1
-                    break
-            if root_pages_obj_no == -1:
-                raise SystemExit("Error on PDF Pages objects numbering.")
-            return catalog_obj_no, root_pages_obj_no
-        return catalog_obj_no
+def fnd_unuse_no(obj_no, top_pages_obj_no):
+    unuse_no = -1
+    for i in range(9999):
+        if (i + 1 not in obj_no) and (i + 1 not in top_pages_obj_no):
+            unuse_no = i + 1
+            break
+    if unuse_no == -1:
+        raise SystemExit("Error on PDF objects numbering.")
+    return unuse_no
 
 
 def make_dest(pdfw, pg):


### PR DESCRIPTION
 主要是这么几项内容;

- (1) 有遇到文档的toc数据在'\x00'后并不全是'\x00'，而是乱码的情况，这就不能用替换的方法把多余的字节换成''了，所以只好把'\x00'和其之后的数据都丢弃掉；

- (2) 有遇到文档的PDF数据中各个对象之间有破损且重复的对象数据，所以采用的方法是从每一个'endobj'开始向前反推到这个对象的开头，并依次加入到最后的PDF数据中；

 - (3) Pages对象缺失的情况比已知的要复杂：

    - a. 所有Pages对象已经存在
       最好不要直接取最小的pages_obj_no中的值作为root_pages_obj_no，而是找出相应的对象编号
    - b. 根Pages对象不存在，即只缺失了一个Pages对象
        相对容易处理
    - c. 多个Pages对象不存在
        相对复杂一些： 首先，为根Pages对象分配一个未使用过的对象编号；然后，按照处理b的方法建一个根Pages对象；接着，为所有缺失的Pages确定/Kids和/Count属性的值，在确定/Count的值时要区分相应的子对象的/Type属性是Pages还是Page；最后，把这些对象依次添加到PDF数据中。